### PR TITLE
Add mdbook build and test

### DIFF
--- a/.github/workflows/mdbook-build-test.yml
+++ b/.github/workflows/mdbook-build-test.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pages:
+    name: mdbook build/test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Setup mdBook
+      uses: peaceiris/actions-mdbook@v1
+      with:
+        mdbook-version: 'latest'
+
+    - name: mdbook build and test
+      run: |
+        mdbook build
+        mdbook test
+

--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "开源雨林 - 开源通识教程"
+
+[build]
+create-missing = false


### PR DESCRIPTION
- Add mdbook build and test check to avoid potential wrong link.
- Disable `create-missing` to make wrong link fast-failed. See more in [link](https://rust-lang.github.io/mdBook/format/configuration/general.html#build-options).